### PR TITLE
Enhance normalize uri

### DIFF
--- a/org.sonatype.m2e.egit.feature/pom.xml
+++ b/org.sonatype.m2e.egit.feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonatype.m2e.egit</groupId>
     <artifactId>org.sonatype.m2e.egit.parent</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.egit.feature</artifactId>

--- a/org.sonatype.m2e.egit.repository/pom.xml
+++ b/org.sonatype.m2e.egit.repository/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonatype.m2e.egit</groupId>
     <artifactId>org.sonatype.m2e.egit.parent</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.egit.repository</artifactId>

--- a/org.sonatype.m2e.egit.tests/.classpath
+++ b/org.sonatype.m2e.egit.tests/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/org.sonatype.m2e.egit.tests/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.egit.tests/META-INF/MANIFEST.MF
@@ -2,13 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Maven SCM Handler for EGit Tests
 Bundle-SymbolicName: org.sonatype.m2e.egit.tests;singleton:=true
-Bundle-Version: 0.14.0.qualifier
+Bundle-Version: 0.15.0.qualifier
 Bundle-Vendor: Sonatype
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.m2e.core,
  org.eclipse.m2e.scm,
  org.eclipse.m2e.tests.common,
  org.eclipse.m2e.maven.runtime,
+ org.eclipse.jgit;bundle-version="[3.0.0,5.0.0)",
  org.sonatype.m2e.egit,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.sonatype.m2e.egit.tests/pom.xml
+++ b/org.sonatype.m2e.egit.tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonatype.m2e.egit</groupId>
     <artifactId>org.sonatype.m2e.egit.parent</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.egit.tests</artifactId>

--- a/org.sonatype.m2e.egit.tests/src/org/sonatype/m2e/egit/tests/EgitScmHandlerTest.java
+++ b/org.sonatype.m2e.egit.tests/src/org/sonatype/m2e/egit/tests/EgitScmHandlerTest.java
@@ -9,7 +9,16 @@
 package org.sonatype.m2e.egit.tests;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.m2e.scm.MavenProjectScmInfo;
 import org.eclipse.ui.PlatformUI;
 import org.sonatype.m2e.egit.internal.EgitScmHandler;
 
@@ -41,5 +50,119 @@ public class EgitScmHandlerTest extends AbstractScmHandlerTest {
     waitForJobsToComplete();
 
     assertWorkspaceProject("git-test");
+  }
+
+  public void testNormalizeURI() throws Exception {
+    EgitScmHandlerExt handler = new EgitScmHandlerExt();
+
+    String uri = EgitScmHandler.GIT_SCM_ID + "git@github.com:errai/errai.git/errai-common";
+
+    assertEquals("ssh://git@github.com/errai/errai.git", handler.normalizeUri(uri, false));
+    assertEquals("git://github.com/errai/errai.git", handler.normalizeUri(uri, true));
+  }
+
+  /**
+   * Authentication success is mocked.
+   * Expected:
+   * 	- no exception,
+   * 	- EgitScmHandler.runCloneOperation() is called,
+   * 	- EgitScmHandler.onAuthFailed() is not called.
+   */
+  public void testAuthFailed1() throws Exception {
+    EgitScmHandlerExt handler = new EgitScmHandlerExt();
+    String url = EgitScmHandlerExt.GIT_SCM_ID + "git@github.com:errai/errai.git/errai-common";
+    MavenProjectScmInfo scmInfo = new MavenProjectScmInfo(url, null, null, "HEAD", url, url);
+    CoreException exc = null;
+    try {
+      handler.checkoutProject(scmInfo, null, new NullProgressMonitor());
+    } catch (CoreException e) {
+    	exc = e;
+    }
+    assertNull(exc);
+    assertEquals(1, handler.callsOfrunCloneOperation);
+    assertEquals(0, handler.callsOfonAuthFailed);
+  }
+
+  /**
+   * Authentication failure is mocked, user selects cancel to connect anonymously.
+   * Expected:
+   * 	- no exception,
+   * 	- EgitScmHandler.runCloneOperation() is called,
+   * 	- EgitScmHandler.onAuthFailed() is called.
+   */
+  public void testAuthFailed2() throws Exception {
+    EgitScmHandlerExt handler = new EgitScmHandlerExt(true, false);
+    String url = EgitScmHandlerExt.GIT_SCM_ID + "git@github.com:errai/errai.git/errai-common";
+    MavenProjectScmInfo scmInfo = new MavenProjectScmInfo(url, null, null, "HEAD", url, url);
+    CoreException exc = null;
+    try {
+      handler.checkoutProject(scmInfo, null, new NullProgressMonitor());
+    } catch (CoreException e) {
+      exc = e;
+    }
+    assertNull(exc);
+    assertEquals(1, handler.callsOfrunCloneOperation);
+    assertEquals(1, handler.callsOfonAuthFailed);
+  }
+
+  /**
+   * Authentication failure is mocked, user selects ok to connect anonymously.
+   * Expected:
+   * 	- no exception,
+   * 	- EgitScmHandler.runCloneOperation() is called twice,
+   * 	- EgitScmHandler.onAuthFailed() is called.
+   */
+  public void testAuthFailed3() throws Exception {
+    EgitScmHandlerExt handler = new EgitScmHandlerExt(true, true);
+    String url = EgitScmHandlerExt.GIT_SCM_ID + "git@github.com:errai/errai.git/errai-common";
+    MavenProjectScmInfo scmInfo = new MavenProjectScmInfo(url, null, null, "HEAD", url, url);
+    CoreException exc = null;
+    try {
+      handler.checkoutProject(scmInfo, null, new NullProgressMonitor());
+    } catch (CoreException e) {
+      exc = e;
+	}
+	assertNull(exc);
+	assertEquals(2, handler.callsOfrunCloneOperation);
+	assertEquals(1, handler.callsOfonAuthFailed);
+  }
+
+  class EgitScmHandlerExt extends EgitScmHandler {
+    boolean throwAuthFailed = false;
+    boolean accessAnonymously = false;
+    
+    int callsOfonAuthFailed = 0;
+    int callsOfrunCloneOperation = 0;
+
+    EgitScmHandlerExt() {}
+
+    EgitScmHandlerExt(boolean throwAuthFailed, boolean accessAnonymously) {
+      this.throwAuthFailed = throwAuthFailed;
+      this.accessAnonymously = accessAnonymously;
+    }
+
+    //Make normalizeUri(String, boolean) accessible.
+    @Override
+    public String normalizeUri(String uri, boolean avoidSSH) throws URISyntaxException {
+      return super.normalizeUri(uri, avoidSSH);
+    }
+
+    //Mock super
+    @Override
+    protected void runCloneOperation(URIish uri, File location, String refName, SubMonitor pm)
+              throws InvocationTargetException, IOException, InterruptedException {
+      callsOfrunCloneOperation++;
+      if(throwAuthFailed) {
+        throwAuthFailed = false; //next time run smoothly.
+  	    throw new InvocationTargetException(new TransportException("Auth failed"));
+      }
+	}
+
+    //Mock super
+    @Override
+    protected boolean onAuthFailed() {
+      callsOfonAuthFailed++;
+      return accessAnonymously;
+    }
   }
 }

--- a/org.sonatype.m2e.egit/.classpath
+++ b/org.sonatype.m2e.egit/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/org.sonatype.m2e.egit/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.egit/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.sonatype.m2e.egit;singleton:=true
-Bundle-Version: 0.14.0.qualifier
+Bundle-Version: 0.15.0.qualifier
 Bundle-Vendor: %Bundle-Vendor
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.scm;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.m2e.core.ui;bundle-version="[1.0.0,2.0.0)",

--- a/org.sonatype.m2e.egit/pom.xml
+++ b/org.sonatype.m2e.egit/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.sonatype.m2e.egit</groupId>
     <artifactId>org.sonatype.m2e.egit.parent</artifactId>
-    <version>0.14.0-SNAPSHOT</version>
+    <version>0.15.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.sonatype.m2e.egit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>org.sonatype.m2e.egit</groupId>
   <artifactId>org.sonatype.m2e.egit.parent</artifactId>
-  <version>0.14.0-SNAPSHOT</version>
+  <version>0.15.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Maven SCM Handler for EGit Parent</name>
 


### PR DESCRIPTION
Changes:
1) remove tail after .git

2) In case SSH protocol is used and failed, suggest connecting git anonymously.
If user cancels, do nothing, just cancel the operation.
If user confirms,
  a) set git:// instead git@
  b) set host/ instead host:

Steps to reproduce:
1. Clone https://github.com/jenkinsci/jenkins
2. Import into Eclipse as a maven project.
3. Select in cli project in Maven Dependencies javassist-3.19.0.GA.jar and call Maven-> Import project(s) from SCM. 'Select Maven artifacts' press Next, then Finish.
4. If you have ssh key:
Expected result: repository will be cloned, and 'Select Maven Projects' page will appear with projects to import. 
Current failure: 'Select Maven Projects' page appears empty.
Fixed by (1 - remove tail after .git) 
5. If you do not have ssh key:
Expected result: a dialog 'Auth fail' appears that suggests connecting git anonymously. If accepted, continues as in 4.
Current failure: 'Select Maven Projects' page appears empty.
After fix of (1) - failure - system error dialog reporting exception 'Auth failed'.
Fixed by (1) and (2).
