### PR TITLE
Add support for EGit 6

### DIFF
--- a/org.sonatype.m2e.egit/META-INF/MANIFEST.MF
+++ b/org.sonatype.m2e.egit/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Require-Bundle: org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.ui,
  org.eclipse.swt,
  org.eclipse.jface,
- org.eclipse.egit.core;bundle-version="[3.0.0,6.0.0)",
- org.eclipse.egit.ui;bundle-version="[3.0.0,6.0.0)",
- org.eclipse.jgit;bundle-version="[3.0.0,6.0.0)"
+ org.eclipse.egit.core;bundle-version="[3.0.0,7.0.0)",
+ org.eclipse.egit.ui;bundle-version="[3.0.0,7.0.0)",
+ org.eclipse.jgit;bundle-version="[3.0.0,7.0.0)"
 Export-Package: org.sonatype.m2e.egit.internal;x-internal:=true
 Import-Package: org.slf4j;version="1.5.11"


### PR DESCRIPTION
Fixes #19 

I was unable to locate a changelog for EGit and JGit to see if anything will break with the major version change.
However, looking at the changes made to support EGit 5, it was as simple as updating the bundle requirements, which I have done in this PR.